### PR TITLE
Convenience methods for Colony graph (and more)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -53,6 +53,7 @@
 - [Ethers6Filter](interfaces/Ethers6Filter.md)
 - [Ethers6FilterByBlockHash](interfaces/Ethers6FilterByBlockHash.md)
 - [EventSources](interfaces/EventSources.md)
+- [GraphDomain](interfaces/GraphDomain.md)
 - [IpfsAdapter](interfaces/IpfsAdapter.md)
 - [MetaTxBaseContract](interfaces/MetaTxBaseContract.md)
 - [NetworkClientOptions](interfaces/NetworkClientOptions.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -25,6 +25,7 @@
 - [CloudflareReadonlyAdapter](classes/CloudflareReadonlyAdapter.md)
 - [Colony](classes/Colony.md)
 - [ColonyEventManager](classes/ColonyEventManager.md)
+- [ColonyGraph](classes/ColonyGraph.md)
 - [ColonyNetwork](classes/ColonyNetwork.md)
 - [ColonyToken](classes/ColonyToken.md)
 - [ColonyTxCreator](classes/ColonyTxCreator.md)
@@ -57,6 +58,7 @@
 - [NetworkClientOptions](interfaces/NetworkClientOptions.md)
 - [ParsedLogTransactionReceipt](interfaces/ParsedLogTransactionReceipt.md)
 - [PermissionConfig](interfaces/PermissionConfig.md)
+- [SubgraphClientOptions](interfaces/SubgraphClientOptions.md)
 - [SupportedExtensions](interfaces/SupportedExtensions.md)
 - [TxConfig](interfaces/TxConfig.md)
 - [TxCreatorConfig](interfaces/TxCreatorConfig.md)
@@ -121,6 +123,66 @@ Check if two addresses are equal
 #### Returns
 
 `boolean`
+
+___
+
+### createSubgraphClient
+
+▸ **createSubgraphClient**(`options?`): `Client`
+
+Creates a Colony Subgraph client
+
+The Colony Subgraph client is nothing else than a ready-to-use [`urql`](https://formidable.com/open-source/urql/) client connected to the Colony Subgraph with subscriptions enabled. Please refer to the following references if you'd like to know more about [The Graph](https://thegraph.com/) or [GraphQL](https://graphql.org/) in general.
+
+The Colony Subgraph's schema and resolvers are kept up-to-date by the Colony team and can be explored here: [Colony Subgraph](https://thegraph.com/hosted-service/subgraph/joincolony/colony-xdai). There you can make test queries to the Colony Subgraph and explore it all the way down the rabbit hole :)
+
+**`Example`**
+
+Retrieve the 10 most recent "DomainAdded" events across all Colonies
+```typescript
+import { createSubgraphClient, gql } from '@colony/sdk/graph';
+
+const colonySubgraph = createSubgraphClient();
+
+const QUERY = gql`
+  query DomainAddedEvents {
+    events(
+      first: 10
+      orderBy: timestamp
+      orderDirection: desc
+      where: { name_contains: "DomainAdded" }
+    ) {
+      id
+      address
+      associatedColony {
+        colonyAddress: id
+      }
+      name
+      args
+      timestamp
+    }
+  }
+`;
+
+colonySubgraph
+  .query(QUERY)
+  .toPromise()
+  .then((result) => {
+    console.info(result.data.events[0]);
+  });
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | [`SubgraphClientOptions`](interfaces/SubgraphClientOptions.md) | Define configuration options to instantiate the client with |
+
+#### Returns
+
+`Client`
+
+A ready-to-use `urql` GraphQL client instance
 
 ___
 
@@ -191,6 +253,49 @@ Version of `getLogs` that also supports filtering for multiple addresses
 #### Returns
 
 `Promise`<`Log`[]\>
+
+___
+
+### gql
+
+▸ **gql**<`Data`, `Variables`\>(`strings`, ...`interpolations`): `TypedDocumentNode`<`Data`, `Variables`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Data` | `any` |
+| `Variables` | `object` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `strings` | `TemplateStringsArray` |
+| `...interpolations` | (`string` \| `DocumentNode` \| `TypedDocumentNode`<{ `[key: string]`: `any`;  }, { `[key: string]`: `any`;  }\>)[] |
+
+#### Returns
+
+`TypedDocumentNode`<`Data`, `Variables`\>
+
+▸ **gql**<`Data`, `Variables`\>(`string`): `TypedDocumentNode`<`Data`, `Variables`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Data` | `any` |
+| `Variables` | `object` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `string` | `string` |
+
+#### Returns
+
+`TypedDocumentNode`<`Data`, `Variables`\>
 
 ___
 

--- a/docs/api/classes/Colony.md
+++ b/docs/api/classes/Colony.md
@@ -44,6 +44,14 @@ import { w } from '@colony/sdk';
 
 ___
 
+### graph
+
+• **graph**: `default`
+
+A helper class to retrieve data from the Colony graph database
+
+___
+
 ### signerOrProvider
 
 • **signerOrProvider**: `SignerOrProvider`

--- a/docs/api/classes/Colony.md
+++ b/docs/api/classes/Colony.md
@@ -46,7 +46,7 @@ ___
 
 ### graph
 
-• **graph**: `default`
+• **graph**: [`ColonyGraph`](ColonyGraph.md)
 
 A helper class to retrieve data from the Colony graph database
 

--- a/docs/api/classes/ColonyGraph.md
+++ b/docs/api/classes/ColonyGraph.md
@@ -18,8 +18,16 @@ Do not instantiate manually. Use the `graph` property on a Colony to access this
 
 ### getTeamsWithMetadata
 
-▸ **getTeamsWithMetadata**(): `Promise`<``null`` \| `Domain`[]\>
+▸ **getTeamsWithMetadata**(): `Promise`<``null`` \| [`GraphDomain`](../interfaces/GraphDomain.md)[]\>
+
+Fetch all teams of a Colony including their Metadata
+
+**`Deprecated`**
+
+- will be replaced in v2.0
+
+This queries the Colony graph database for all teams including their metadata. The metadata is fetched from IPFS
 
 #### Returns
 
-`Promise`<``null`` \| `Domain`[]\>
+`Promise`<``null`` \| [`GraphDomain`](../interfaces/GraphDomain.md)[]\>

--- a/docs/api/classes/ColonyGraph.md
+++ b/docs/api/classes/ColonyGraph.md
@@ -1,0 +1,25 @@
+# Class: ColonyGraph
+
+## Constructors
+
+### constructor
+
+• **new ColonyGraph**(`colony`)
+
+Do not instantiate manually. Use the `graph` property on a Colony to access this class
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `colony` | [`Colony`](Colony.md) |
+
+## Methods
+
+### getTeamsWithMetadata
+
+▸ **getTeamsWithMetadata**(): `Promise`<``null`` \| `Domain`[]\>
+
+#### Returns
+
+`Promise`<``null`` \| `Domain`[]\>

--- a/docs/api/classes/ColonyNetwork.md
+++ b/docs/api/classes/ColonyNetwork.md
@@ -8,6 +8,12 @@
 
 ___
 
+### graphClient
+
+• **graphClient**: `Client`
+
+___
+
 ### ipfs
 
 • **ipfs**: `IpfsMetadata`

--- a/docs/api/classes/VotingReputation.md
+++ b/docs/api/classes/VotingReputation.md
@@ -276,6 +276,36 @@ A transaction creator
 
 ___
 
+### escalateMotion
+
+▸ **escalateMotion**(`motionId`, `newTeamId`): [`MetaTxCreator`](MetaTxCreator.md)<`VotingReputationClientV8`, ``"escalateMotion"``, { `domainId?`: `BigNumber` ; `escalator?`: `string` ; `motionId?`: `BigNumber` ; `newDomainId?`: `BigNumber`  }, [`MetadataType`](../enums/MetadataType.md)\>
+
+Escalate a motion to a parent team
+
+If all votes for a motion have been revealed but a user is not happy with the outcome, it can be escalated to a parent team (including grandparents, great-grandparents, etc.) as long as the escalation period has not passed yet.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `motionId` | `BigNumberish` | The motionId of the motion to be escalated |
+| `newTeamId` | `BigNumberish` | The id of the team the motion should be escalated to |
+
+#### Returns
+
+[`MetaTxCreator`](MetaTxCreator.md)<`VotingReputationClientV8`, ``"escalateMotion"``, { `domainId?`: `BigNumber` ; `escalator?`: `string` ; `motionId?`: `BigNumber` ; `newDomainId?`: `BigNumber`  }, [`MetadataType`](../enums/MetadataType.md)\>
+
+A transaction creator
+
+#### Event data
+
+| Property | Type | Description |
+| :------ | :------ | :------ |
+| `motionId` | BigNumber | ID of the motion to be escalated |
+| `newTeamId` | string | The ID of the team the motion should be escalated to (has to be a direct parent of the previous team) |
+
+___
+
 ### finalizeMotion
 
 ▸ **finalizeMotion**(`motionId`): [`MetaTxCreator`](MetaTxCreator.md)<`VotingReputationClientV8`, ``"finalizeMotion"``, { `action?`: `string` ; `executed?`: `boolean` ; `motionId?`: `BigNumber`  }, [`MetadataType`](../enums/MetadataType.md)\>
@@ -458,7 +488,7 @@ A transaction creator
 
 | Property | Type | Description |
 | :------ | :------ | :------ |
-| `motionId` | BigNumber | ID of the motion created |
+| `motionId` | BigNumber | ID of the motion to be revealed |
 | `voter` | string | The address of the user who voted |
 | `vote` | BigNumber | The vote that was cast (0 = Nay, 1 = Yay) |
 
@@ -512,7 +542,7 @@ A transaction creator
 
 | Property | Type | Description |
 | :------ | :------ | :------ |
-| `motionId` | BigNumber | ID of the motion created |
+| `motionId` | BigNumber | ID of the motion to stake for |
 | `staker` | string | The address that staked the tokens |
 | `vote` | Vote | The vote that was staked for (Yay or Nay). See [Vote](../enums/Vote.md) |
 | `amount` | BigNumber | The amount that was staked for that vote |
@@ -547,7 +577,7 @@ A transaction creator
 
 | Property | Type | Description |
 | :------ | :------ | :------ |
-| `motionId` | BigNumber | ID of the motion created |
+| `motionId` | BigNumber | ID of the motion to submit a vote for |
 | `voter` | string | The address of the user who voted |
 
 ___

--- a/docs/api/interfaces/ColonyNetworkOptions.md
+++ b/docs/api/interfaces/ColonyNetworkOptions.md
@@ -4,6 +4,14 @@ Additional options for the [ColonyNetwork](../classes/ColonyNetwork.md)
 
 ## Properties
 
+### graphOptions
+
+• `Optional` **graphOptions**: `SubgraphClientOptions`
+
+Provide custom GraphQL client options
+
+___
+
 ### ipfsAdapter
 
 • `Optional` **ipfsAdapter**: [`IpfsAdapter`](IpfsAdapter.md)

--- a/docs/api/interfaces/ColonyNetworkOptions.md
+++ b/docs/api/interfaces/ColonyNetworkOptions.md
@@ -6,7 +6,7 @@ Additional options for the [ColonyNetwork](../classes/ColonyNetwork.md)
 
 ### graphOptions
 
-• `Optional` **graphOptions**: `SubgraphClientOptions`
+• `Optional` **graphOptions**: [`SubgraphClientOptions`](SubgraphClientOptions.md)
 
 Provide custom GraphQL client options
 

--- a/docs/api/interfaces/DomainMetadata.md
+++ b/docs/api/interfaces/DomainMetadata.md
@@ -1,5 +1,11 @@
 # Interface: DomainMetadata
 
+## Hierarchy
+
+- **`DomainMetadata`**
+
+  ↳ [`GraphDomain`](GraphDomain.md)
+
 ## Properties
 
 ### domainColor

--- a/docs/api/interfaces/GraphDomain.md
+++ b/docs/api/interfaces/GraphDomain.md
@@ -1,0 +1,55 @@
+# Interface: GraphDomain
+
+## Hierarchy
+
+- [`DomainMetadata`](DomainMetadata.md)
+
+  ↳ **`GraphDomain`**
+
+## Properties
+
+### domainColor
+
+• `Optional` **domainColor**: `number`
+
+#### Inherited from
+
+[DomainMetadata](DomainMetadata.md).[domainColor](DomainMetadata.md#domaincolor)
+
+___
+
+### domainName
+
+• `Optional` **domainName**: `string`
+
+#### Inherited from
+
+[DomainMetadata](DomainMetadata.md).[domainName](DomainMetadata.md#domainname)
+
+___
+
+### domainPurpose
+
+• `Optional` **domainPurpose**: `string`
+
+#### Inherited from
+
+[DomainMetadata](DomainMetadata.md).[domainPurpose](DomainMetadata.md#domainpurpose)
+
+___
+
+### id
+
+• **id**: `number`
+
+___
+
+### metadata
+
+• **metadata**: `string`
+
+___
+
+### name
+
+• **name**: `string`

--- a/docs/api/interfaces/SubgraphClientOptions.md
+++ b/docs/api/interfaces/SubgraphClientOptions.md
@@ -1,0 +1,17 @@
+# Interface: SubgraphClientOptions
+
+## Properties
+
+### endpointHttp
+
+• `Optional` **endpointHttp**: `string`
+
+The GraphQL endpoint for HTTP connections
+
+___
+
+### endpointWs
+
+• `Optional` **endpointWs**: `string`
+
+The GraphQL endpoint for Websocket connections

--- a/examples/node/graph-colony.ts
+++ b/examples/node/graph-colony.ts
@@ -1,0 +1,17 @@
+import { providers } from 'ethers';
+
+import { ColonyNetwork, ColonyRpcEndpoint } from '../../src';
+
+const provider = new providers.JsonRpcProvider(ColonyRpcEndpoint.Gnosis);
+
+// Get the Metacolony's domains including their metadata
+const start = async () => {
+  const colonyNetwork = await ColonyNetwork.init(provider);
+  const colony = await colonyNetwork.getColony(
+    '0x364B3153A24bb9ECa28B8c7aCeB15E3942eb4fc5',
+  );
+  const data = await colony.graph.getTeamsWithMetadata();
+  console.info(data);
+};
+
+start();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colony/sdk",
-  "version": "1.1.0",
+  "version": "1.2.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@colony/sdk",
-      "version": "1.1.0",
+      "version": "1.2.0-beta.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@colony/colony-event-metadata-parser": "^2.0.0-beta.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colony/sdk",
-  "version": "1.2.0-beta.0",
+  "version": "1.2.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@colony/sdk",
-      "version": "1.2.0-beta.0",
+      "version": "1.2.0-beta.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@colony/colony-event-metadata-parser": "^2.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/sdk",
-  "version": "1.1.0",
+  "version": "1.2.0-beta.0",
   "license": "GPL-3.0-only",
   "dependencies": {
     "@colony/colony-event-metadata-parser": "^2.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colony/sdk",
-  "version": "1.2.0-beta.0",
+  "version": "1.2.0-beta.1",
   "license": "GPL-3.0-only",
   "dependencies": {
     "@colony/colony-event-metadata-parser": "^2.0.0-beta.1",

--- a/src/ColonyNetwork/Colony.ts
+++ b/src/ColonyNetwork/Colony.ts
@@ -58,6 +58,7 @@ import {
   VotingReputation,
 } from './VotingReputation';
 import { ERC2612Token } from './ERC2612Token';
+import ColonyGraph from '../graph/ColonyGraph';
 
 export type SupportedColonyClient = ColonyClientV11;
 export type SupportedColonyMethods = SupportedColonyClient['functions'];
@@ -134,6 +135,11 @@ export class Colony {
   ext: SupportedExtensions;
 
   /**
+   * A helper class to retrieve data from the Colony graph database
+   */
+  graph: ColonyGraph;
+
+  /**
    * Contract version
    *
    * Colony contracts are upgradable! Here you'll finde the currently installed version of the contract
@@ -160,6 +166,7 @@ export class Colony {
     this.signerOrProvider = colonyClient.signer || colonyClient.provider;
     this.address = colonyClient.address;
     this.ext = {};
+    this.graph = new ColonyGraph(this);
     switch (colonyClient.tokenClient.tokenClientType) {
       case TokenClientType.Erc20: {
         this.token = new ERC20Token(

--- a/src/ColonyNetwork/ColonyNetwork.ts
+++ b/src/ColonyNetwork/ColonyNetwork.ts
@@ -25,6 +25,9 @@ import {
   ColonyMetadata,
   MetadataType,
 } from '@colony/colony-event-metadata-parser';
+import { Client } from '@urql/core';
+
+import { createSubgraphClient, SubgraphClientOptions } from '../../src/graph';
 
 import { IpfsMetadata, IpfsAdapter } from '../ipfs';
 import { BaseContract, TxConfig, TxCreator, MetaTxCreator } from '../TxCreator';
@@ -50,6 +53,8 @@ export interface ColonyNetworkOptions {
   networkClientOptions?: NetworkClientOptions;
   /** Provide a custom metatransaction broadcaster endpoint */
   metaTxBroadcasterEndpoint?: string;
+  /** Provide custom GraphQL client options */
+  graphOptions?: SubgraphClientOptions;
 }
 
 export interface ColonyNetworkConfig {
@@ -58,6 +63,8 @@ export interface ColonyNetworkConfig {
 
 export class ColonyNetwork {
   config: ColonyNetworkConfig;
+
+  graphClient: Client;
 
   ipfs: IpfsMetadata;
 
@@ -93,6 +100,7 @@ export class ColonyNetwork {
     this.locking = new TokenLocking(this, tokenLockingClient);
     this.networkClient = networkClient;
     this.signerOrProvider = signerOrProvider;
+    this.graphClient = createSubgraphClient();
   }
 
   /**

--- a/src/graph/ColonyGraph.ts
+++ b/src/graph/ColonyGraph.ts
@@ -1,0 +1,63 @@
+import {
+  DomainMetadata,
+  MetadataType,
+} from '@colony/colony-event-metadata-parser';
+import { gql } from '@urql/core';
+
+import { Colony } from '../ColonyNetwork';
+
+interface Domain extends DomainMetadata {
+  id: number;
+  name: string;
+  metadata: string;
+}
+
+export default class ColonyGraph {
+  private colony: Colony;
+
+  constructor(colony: Colony) {
+    this.colony = colony;
+  }
+
+  /*
+   * Fetch all teams of a Colony including their Metadata
+   *
+   * @deprecated - will be replaced in v2.0
+   *
+   * This queries the Colony graph database for all teams including their metadata. The metadata is fetched from IPFS
+   */
+  async getTeamsWithMetadata() {
+    const query = gql`
+      query Domains($colonyAddress: String!) {
+        domains(where: { colonyAddress: $colonyAddress }) {
+          id: domainChainId
+          name
+          metadata
+        }
+      }
+    `;
+    const colonyAddress = this.colony.address.toLowerCase();
+    const result = await this.colony.colonyNetwork.graphClient
+      .query(query, { colonyAddress })
+      .toPromise();
+    if (result && result.data) {
+      const metadataPromises = result.data.domains.map((domain: Domain) => {
+        if (!domain.metadata) {
+          return Promise.resolve({});
+        }
+        return this.colony.colonyNetwork.ipfs.getMetadata(
+          MetadataType.Domain,
+          domain.metadata,
+        );
+      });
+      const metadata = await Promise.all(metadataPromises);
+      return result.data.domains.map((domain: Domain, idx: number) => ({
+        ...domain,
+        ...metadata[idx],
+        id: parseInt(domain.id as unknown as string, 10),
+      })) as Domain[];
+    }
+
+    return null;
+  }
+}

--- a/src/graph/ColonyGraph.ts
+++ b/src/graph/ColonyGraph.ts
@@ -15,6 +15,9 @@ interface Domain extends DomainMetadata {
 export default class ColonyGraph {
   private colony: Colony;
 
+  /**
+   * Do not instantiate manually. Use the `graph` property on a Colony to access this class
+   */
   constructor(colony: Colony) {
     this.colony = colony;
   }

--- a/src/graph/ColonyGraph.ts
+++ b/src/graph/ColonyGraph.ts
@@ -6,7 +6,7 @@ import { gql } from '@urql/core';
 
 import { Colony } from '../ColonyNetwork';
 
-interface Domain extends DomainMetadata {
+export interface GraphDomain extends DomainMetadata {
   id: number;
   name: string;
   metadata: string;
@@ -22,7 +22,7 @@ export default class ColonyGraph {
     this.colony = colony;
   }
 
-  /*
+  /**
    * Fetch all teams of a Colony including their Metadata
    *
    * @deprecated - will be replaced in v2.0
@@ -44,21 +44,23 @@ export default class ColonyGraph {
       .query(query, { colonyAddress })
       .toPromise();
     if (result && result.data) {
-      const metadataPromises = result.data.domains.map((domain: Domain) => {
-        if (!domain.metadata) {
-          return Promise.resolve({});
-        }
-        return this.colony.colonyNetwork.ipfs.getMetadata(
-          MetadataType.Domain,
-          domain.metadata,
-        );
-      });
+      const metadataPromises = result.data.domains.map(
+        (domain: GraphDomain) => {
+          if (!domain.metadata) {
+            return Promise.resolve({});
+          }
+          return this.colony.colonyNetwork.ipfs.getMetadata(
+            MetadataType.Domain,
+            domain.metadata,
+          );
+        },
+      );
       const metadata = await Promise.all(metadataPromises);
-      return result.data.domains.map((domain: Domain, idx: number) => ({
+      return result.data.domains.map((domain: GraphDomain, idx: number) => ({
         ...domain,
         ...metadata[idx],
         id: parseInt(domain.id as unknown as string, 10),
-      })) as Domain[];
+      })) as GraphDomain[];
     }
 
     return null;

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -98,4 +98,4 @@ export const createSubgraphClient = (options?: SubgraphClientOptions) => {
  */
 export { gql } from '@urql/core';
 
-export { default as ColonyGraph } from './ColonyGraph';
+export { default as ColonyGraph, GraphDomain } from './ColonyGraph';

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -87,6 +87,8 @@ export const createSubgraphClient = (options?: SubgraphClientOptions) => {
   });
 };
 
+// TODO: add createSubgraphClientWithSubscription (or something like that) which is basically the above and remove the subscription stuff from the above
+
 /**
  * The `gql` interpolation function
  *

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -19,6 +19,8 @@ export interface SubgraphClientOptions {
   endpointWs?: string;
 }
 
+// TODO: (v2) remove this file from package.json as separate module
+
 /**
  * Creates a Colony Subgraph client
  *
@@ -95,3 +97,5 @@ export const createSubgraphClient = (options?: SubgraphClientOptions) => {
  * This is just the passed-down [`gql`](https://formidable.com/open-source/urql/docs/api/core/#gql) function from `urlq`. This function is used to parse GraphQL queries as strings and create query objects the GraphQL client can process. Please check out it's documentation to get to know more.
  */
 export { gql } from '@urql/core';
+
+export { default as ColonyGraph } from './ColonyGraph';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type {
 export * from './ColonyNetwork';
 export * from './TxCreator';
 export * from './events';
+export * from './graph';
 export * from './ipfs';
 export * from './constants';
 export * from './utils';


### PR DESCRIPTION
This PR sets the base for future convenience methods that require a Colony graph server.

These methods will be found under `colony.graph` on any instantiated colony and on `colonyNetwork.graph` (if applicable).

Furthermore this PR adds the missing `escalateMotion` method to the `VotingReputation` extension